### PR TITLE
Fix the URL for the final version of exercise 4.3

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -67,7 +67,7 @@ quick extra credit).
 
 ### 3. 💯 add game history feature
 
-Open `http://localhost:3000/isolated/final/04.extra-2.js` and see that the extra
+Open `http://localhost:3000/isolated/final/04.extra-3.js` and see that the extra
 version supports keeping a history of the game and allows you to go backward and
 forward in time. See if you can implement that!
 


### PR DESCRIPTION
The documentation of the exercise points to 

```http://localhost:3000/isolated/final/04.extra-2.js``` 

for the demo with the tic-tac-toe game history feature, but if I am not mistaken the correct URL should be

```http://localhost:3000/isolated/final/04.extra-3.js```.

This PR fixes that.