### PR TITLE
fix: if deserialize give an error show the default value

### DIFF
--- a/src/final/02.extra-4.js
+++ b/src/final/02.extra-4.js
@@ -12,6 +12,8 @@ function useLocalStorageState(
   const [state, setState] = React.useState(() => {
     const valueInLocalStorage = window.localStorage.getItem(key)
     if (valueInLocalStorage) {
+      // the try/catch is here in case the localStorage value was set before
+      // we had the serialization in place (like we do in previous extra credits)
       try {
         return deserialize(valueInLocalStorage)
       } catch (error) {

--- a/src/final/02.extra-4.js
+++ b/src/final/02.extra-4.js
@@ -12,7 +12,11 @@ function useLocalStorageState(
   const [state, setState] = React.useState(() => {
     const valueInLocalStorage = window.localStorage.getItem(key)
     if (valueInLocalStorage) {
-      return deserialize(valueInLocalStorage)
+      try {
+        return deserialize(valueInLocalStorage)
+      } catch (error) {
+        window.localStorage.removeItem(key)
+      }
     }
     return typeof defaultValue === 'function' ? defaultValue() : defaultValue
   })


### PR DESCRIPTION
Using the same name of the key in the `localstorage` for different exercises can cause an issue when running `02.extra-4.js` file because it will try to deserialize the current value that may not be a valid JSON.

With this update if the deserialize function gives an error the default value will be shown.