### PR TITLE
fix: the address of the Pokemon api has moved

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -1,6 +1,6 @@
 import {graphql} from '@kentcdodds/react-workshop-app/server'
 
-const pokemonApi = graphql.link('https://graphql-pokemon.now.sh')
+const pokemonApi = graphql.link('https://graphql-pokemon2.vercel.app/')
 
 export const handlers = [
   pokemonApi.query('PokemonInfo', (req, res, ctx) => {

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -27,8 +27,8 @@ function fetchPokemon(name, delay = 1500) {
   `
 
   return window
-    .fetch('https://graphql-pokemon.now.sh', {
-      // learn more about this API here: https://graphql-pokemon.now.sh/
+    .fetch('https://graphql-pokemon2.vercel.app/', {
+      // learn more about this API here: https://graphql-pokemon2.vercel.app/
       method: 'POST',
       headers: {
         'content-type': 'application/json;charset=UTF-8',


### PR DESCRIPTION
- https://graphql-pokemon.now.sh/ is no longer available and has been moved to https://graphql-pokemon2.vercel.app/