### PR TITLE
Remove unnecessary paragraph that could be confusing to a beginner

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -23,8 +23,9 @@ React.useEffect(async () => {
 
 The reason this doesn't work is because when you make a function async, it
 automatically returns a promise (whether you're not returning anything at all,
-or explicitly returning a function). This is due to the semantics of async/await
-syntax. So if you want to use async/await, the best way to do that is like so:
+or explicitly returning a cleanup function). This is due to the semantics of
+async/await syntax. So if you want to use async/await, the best way to do that
+is like so:
 
 ```javascript
 React.useEffect(() => {
@@ -35,8 +36,6 @@ React.useEffect(() => {
   effect()
 })
 ```
-
-This ensures that you don't return anything but a cleanup function.
 
 🦉 I find that it's typically just easier to extract all the async code into a
 utility function which I call and then use the promise-based `.then` method


### PR DESCRIPTION
As outlined in #45.

I feel that the paragraph following the example is unnecessary, as the paragraph preceding the example explains the reasoning very well:

> (...) when you make a function async, it automatically returns a promise (...) So if you want to use async/await, the best way to do that is like so: