### PR TITLE
Use https for the npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 package-lock=true


### PR DESCRIPTION
Using `http` over `https` was not intentional, and it may cause problems for people in environments which reject non-secure network requests.

https://github.com/kentcdodds/react-fundamentals/pull/80