### PR TITLE
History array should be a deep copy

### DIFF
--- a/src/final/04.extra-3.js
+++ b/src/final/04.extra-3.js
@@ -54,7 +54,7 @@ function Game() {
       return
     }
 
-    const newHistory = history.slice(0, currentStep + 1)
+    const newHistory = history.map(squares => [...squares])
     const squares = [...currentSquares]
 
     squares[square] = nextValue


### PR DESCRIPTION
In the [associated video](https://epicreact.dev/modules/react-hooks/usestate-tic-tac-toe-extra-credit-solution-3), @kentcdodds makes a distinction between how we copied the "squares" array earlier (using spread), now employing Array.slice() to copy the history array of squares arrays.

It's not explicit at this point, but it seemed like this is different because we wanted a _deeper_ copy, however, Array.slice() only does a shallow copy as well ([here's a pen with a quick overview of the different methods](https://codepen.io/ApolaKipso/pen/9a22c0edcbd1ce09b7a94d1b7cf3ca21?editors=0010)).

I think this would be a good point to explain _when_ you need a deeper copy and _how_ to achieve that.
Close this if I misunderstood and am way off base here 😁