### PR TITLE
Add test to avoid bug on multiple square click

### DIFF
--- a/src/__tests__/04.js
+++ b/src/__tests__/04.js
@@ -46,3 +46,12 @@ test('can play a game of tic tac toe', () => {
   userEvent.click(s4)
   expect(s4).toHaveTextContent('')
 })
+
+test('does not change square value when it is clicked multiple times', () => {
+  render(<App />)
+  const [square1] = Array.from(screen.queryAllByRole('button'))
+
+  userEvent.click(square1)
+  userEvent.click(square1)
+  expect(square1).toHaveTextContent('X')
+})


### PR DESCRIPTION
Add test to exercise 04 to avoid forgetting to validate if there's already a value at the given square index.
If the condition `|| squares[square]` in the code below is not added in the exercise, this bug shown in the gif is going to happen, and the current test does not validate this case:

Valid condition:
```
  function selectSquare(square) {
    if (winner || squares[square]) 
      return
    }
```

Invalid condition that currently makes the test pass, but generates this bug below:
```
  function selectSquare(square) {
    if (winner) 
      return
    }
```
![bug on multiple square click](https://user-images.githubusercontent.com/24610813/96538226-71ce9a80-126e-11eb-8947-435684fdda3c.gif)

