### PR TITLE
found a typo

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -236,7 +236,7 @@ their day. They have to first click "Try again" and then select their new
 pokemon. I think it would be cooler if they can just submit a new `pokemonName`
 and the `ErrorBoundary` would reset itself automatically.
 
-Luckily for use `react-error-boundary` supports this with the `resetKeys` prop.
+Luckily for us `react-error-boundary` supports this with the `resetKeys` prop.
 You pass an array of values to `resetKeys` and if the `ErrorBoundary` is in an
 error state and any of those values change, it will reset the error boundary.
 


### PR DESCRIPTION
`Luckily for use` should be `Luckily for us`