### PR TITLE
Use getByRole instead of getByLabelText

### DIFF
--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -6,6 +6,6 @@ import App from '../final/01'
 
 test('typing a name shows a greeting', () => {
   render(<App />)
-  userEvent.type(screen.getByLabelText(/name/i), 'bob')
+  userEvent.type(screen.getByRole('textbox', {name: /name/i}), 'bob')
   screen.getByText(/hello.*bob/i)
 })


### PR DESCRIPTION
This must be just something to be good to change. I noticed `getByLabelText` is used in `src/__tests__/01.js` while `getByRole` is used in `src/__tests__/02.js` in order to select the same input element. I wondered why and learned that `getByRole` is slightly more preferred than `getByLabelText` according to [this guide](https://testing-library.com/docs/guide-which-query).