### PR TITLE
docs: remove incorrect text in 06.md

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -175,8 +175,7 @@ an error. For example:
 1. Type an incorrect pokemon
 2. Notice the error
 3. Type a correct pokemon
-4. Notice it doesn't show that new pokemon's information (even though the
-   network request did work).
+4. Notice it doesn't show that new pokemon's information
 
 The reason this is happening is because the `error` that's stored in the
 internal state of the `ErrorBoundary` component isn't getting reset, so it's not


### PR DESCRIPTION
Extra Credit 5 states that a network request is made even though the pokemon's information isn't displayed. This is incorrect, because the child component which makes the network request is not rendered (at least when following how it was solved in the final solution).

I'm not sure if the text should be removed, or changed to something else. So feel free to suggest something else. 🙂

Thanks for a great course 👍