### PR TITLE
Change prevKeyRef only when needed

### DIFF
--- a/src/final/02.extra-4.js
+++ b/src/final/02.extra-4.js
@@ -29,8 +29,8 @@ function useLocalStorageState(
     const prevKey = prevKeyRef.current
     if (prevKey !== key) {
       window.localStorage.removeItem(prevKey)
+      prevKeyRef.current = key
     }
-    prevKeyRef.current = key
     window.localStorage.setItem(key, serialize(state))
   }, [key, state, serialize])
 


### PR DESCRIPTION
I don't think it is a big difference in this specific scenario but I noticed that we are currently changing the `prevKeyRef.current` every time we go into the hook, this means we are running an assign every time the state changes. It would be nice to optimise the `prevKeyRef.current` to only be assigned when the `key` changes.