### PR TITLE
docs(lift-state): change link to docs using hooks

### DIFF
--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -8,7 +8,7 @@ Elaborate on your learnings here in `src/exercise/03.md`
 
 A common question from React beginners is how to share state between two sibling
 components. The answer is to
-["lift the state"](https://reactjs.org/docs/lifting-state-up.html) which
+["lift the state"](https://reactwithhooks.netlify.app/docs/lifting-state-up.html) which
 basically amounts to finding the lowest common parent shared between the two
 components and placing the state management there, and then passing the state
 and a mechanism for updating that state down into the components that need it.


### PR DESCRIPTION
https://reactwithhooks.netlify.app/docs/lifting-state-up.html is the community-maintained version of reactjs.org with Hooks until React releases new docs version: https://github.com/reactjs/reactjs.org/issues/3308

Do you think worth it to replace the link or at least share both links so students can see the Hooks solution too?