### PR TITLE
Prevent loss of types of state and corresponding setter

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -19,7 +19,7 @@ function useLocalStorageState<TState>(
     deserialize = JSON.parse,
   }: UseLocalStorageOptions<TState> = {},
 ) {
-  const [state, setState] = React.useState(() => {
+  const [state, setState] = React.useState<TState>(() => {
     const valueInLocalStorage = window.localStorage.getItem(key)
     if (valueInLocalStorage) {
       // the try/catch is here in case the localStorage value was set before


### PR DESCRIPTION
The returned state and setState are any without using the TState.