### PR TITLE
fix: test 02 is now working with initialValue set

### DIFF
--- a/src/__tests__/02.js
+++ b/src/__tests__/02.js
@@ -10,7 +10,10 @@ afterEach(() => {
 
 test('App works', () => {
   const {rerender} = render(<App />)
-  userEvent.type(screen.getByRole('textbox', {name: /name/i}), 'bob')
+  const inputTextbox = screen.getByRole('textbox', {name: /name/i})
+  
+  userEvent.clear(inputTextbox)
+  userEvent.type(inputTextbox, 'bob')
   const lsName = window.localStorage.getItem('name')
 
   // extra credit 4 serializes the value in localStorage so there's a bit of a


### PR DESCRIPTION
**Test for exercise 2 was not working correctly**
if `initialName` was set as a prop on the Greeting component, the test failed because the initially set input was not cleared before the test entered 'bob'

**Solution to work**
the solution was to simply clear the input field before typing 'bob'.