### PR TITLE
Update NPM version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For a local development environment, follow the instructions below
 
 - [git][git] v2.13 or greater
 - [NodeJS][node] `14 || 16 || 18`
-- [npm][npm] v6 or greater
+- [npm][npm] v8.16.0 or greater
 
 All of these must be available in your `PATH`. To verify things are set up
 properly, you can run this:


### PR DESCRIPTION
the npm version in package.json and in the Readme are not sync. also if you run the project with npm v6 you will get this error 

```
px: installed 1 in 3.499s
    ▶️  Starting: System Validation
          Ensuring the correct versions of tools are installed on this computer.
          Running the following command: npx "https://gist.github.com/kentcdodds/abbc32701f78fa70298d444c2303b6d9"
npx: installed 2 in 3.22s
There were errors validating the compatibility of this computer:

    This computer has npm@6.14.13 installed, but npm@>=8.16.0 is required. Please update npm by running `npm install --global npm@>=8.16.0`.


If you would like to just ignore this error, then feel free to do so and install dependencies as you normally would in "/Users/mbe/try/react-hooks". Just know that things may not work properly if you do...
    🚨  Failure: System Validation. Please review the messages above for information on how to troubleshoot and resolve this issue.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-hooks@1.0.0 setup: `node setup`
npm ERR! Exit status 1
```