### PR TITLE
Fix: Tic Tac Toe Winner Logic condition check

### DIFF
--- a/src/final/04.extra-1.js
+++ b/src/final/04.extra-1.js
@@ -99,7 +99,7 @@ function calculateWinner(squares) {
   ]
   for (let i = 0; i < lines.length; i++) {
     const [a, b, c] = lines[i]
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+    if (squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a]
     }
   }

--- a/src/final/04.extra-2.js
+++ b/src/final/04.extra-2.js
@@ -96,7 +96,7 @@ function calculateWinner(squares) {
   ]
   for (let i = 0; i < lines.length; i++) {
     const [a, b, c] = lines[i]
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+    if (squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a]
     }
   }

--- a/src/final/04.extra-3.js
+++ b/src/final/04.extra-3.js
@@ -120,7 +120,7 @@ function calculateWinner(squares) {
   ]
   for (let i = 0; i < lines.length; i++) {
     const [a, b, c] = lines[i]
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+    if (squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a]
     }
   }

--- a/src/final/04.js
+++ b/src/final/04.js
@@ -91,7 +91,7 @@ function calculateWinner(squares) {
   ]
   for (let i = 0; i < lines.length; i++) {
     const [a, b, c] = lines[i]
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+    if (squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a]
     }
   }


### PR DESCRIPTION
- it's not necessary to check `squares[a] && squares[a] === squares[b] && squares[a] === squares[c]`
- this is enough to check for winner logic `squares[a] === squares[b] && squares[a] === squares[c]``