### PR TITLE
Add a small note about `Error boundaries do not catch all errors`

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -255,7 +255,7 @@ from `react-error-boundary`.
 💰 It is important to note that `react-error-boundary` do _not_ handle all type of errors.
 In our example it works nicely because as mentioned in extra credit 4 that we are
 throwing error right in the function. It can also happen that some errors are not handled 
-by `react-error-boundary`. To learn more about how to hanlde all the error you can
+by `react-error-boundary`. To learn more about how to handle all type of error you can
 read [Handle all errors](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react#handle-all-errors).
 
 ### 7. 💯 reset the error boundary

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -252,6 +252,12 @@ already installed into this project. It's called
 Go ahead and give that a look and swap out our own `ErrorBoundary` for the one
 from `react-error-boundary`.
 
+💰 It is important to note that `react-error-boundary` do _not_ handle all type of errors.
+In our example it works nicely because as mentioned in extra credit 4 that we are
+throwing error right in the function. It can also happen that some errors are not handled 
+by `react-error-boundary`. To learn more about how to hanlde all the error you can
+read [Handle all errors](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react#handle-all-errors).
+
 ### 7. 💯 reset the error boundary
 
 [Production deploy](https://react-hooks.netlify.app/isolated/final/06.extra-7.js)


### PR DESCRIPTION
**Description**
- It will add a small note about `Error boundaries do not catch all errors`.
- It will also add a link to  [Handle all errors](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react#handle-all-errors)  sections