### PR TITLE
Update outdated links from react website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@kentcdodds/react-workshop-app": "^6.0.1",
+        "@kentcdodds/react-workshop-app": "^6.0.2",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.2.1",
         "codegen.macro": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=8.16.0"
   },
   "dependencies": {
-    "@kentcdodds/react-workshop-app": "^6.0.1",
+    "@kentcdodds/react-workshop-app": "^6.0.2",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.1",
     "codegen.macro": "^4.1.0",

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -8,10 +8,11 @@ Elaborate on your learnings here in `src/exercise/03.md`
 
 A common question from React beginners is how to share state between two sibling
 components. The answer is to
-["lift the state"](https://reactjs.org/docs/lifting-state-up.html) which
-basically amounts to finding the lowest common parent shared between the two
-components and placing the state management there, and then passing the state
-and a mechanism for updating that state down into the components that need it.
+["lift the state"](https://react.dev/learn/sharing-state-between-components)
+which basically amounts to finding the lowest common parent shared between the
+two components and placing the state management there, and then passing the
+state and a mechanism for updating that state down into the components that need
+it.
 
 ## Exercise
 

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -167,12 +167,14 @@ because the `setStatus` call results in a re-render that happens before the
 
 > but it's unable to do this in an asynchronous callback
 
-This is no longer the case in React 18 as it supports automatic batching for asynchronous callback too. 
+This is no longer the case in React 18 as it supports automatic batching for
+asynchronous callback too.
 
 Learn more about this concept here:
-[New Feature: Automatic Batching](https://reactjs.org/blog/2022/03/29/react-v18.html#new-feature-automatic-batching)
+[New Feature: Automatic Batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching)
 
-Still it is better to maintain closely related states as an object rather than maintaining them using individual useState hooks.
+Still it is better to maintain closely related states as an object rather than
+maintaining them using individual useState hooks.
 
 Learn more about this concept here:
 [Should I useState or useReducer?](https://kentcdodds.com/blog/should-i-usestate-or-usereducer#conclusion)
@@ -203,9 +205,9 @@ the user with a blank screen... Kind of awkward...
 
 Luckily for us, there’s a simple way to handle errors in your application using
 a special kind of component called an
-[Error Boundary](https://reactjs.org/docs/error-boundaries.html). Unfortunately,
-there is currently no way to create an Error Boundary component with a function
-and you have to use a class component instead.
+[Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary).
+Unfortunately, there is currently no way to create an Error Boundary component
+with a function and you have to use a class component instead.
 
 In this extra credit, read up on ErrorBoundary components, and try to create one
 that handles this and any other error for the `PokemonInfo` component.
@@ -252,11 +254,12 @@ already installed into this project. It's called
 Go ahead and give that a look and swap out our own `ErrorBoundary` for the one
 from `react-error-boundary`.
 
-💰 It is important to note that `react-error-boundary` do _not_ handle all type of errors.
-In our example it works nicely because as mentioned in extra credit 4 that we are
-throwing error right in the function. It can also happen that some errors are not handled 
-by `react-error-boundary`. To learn more about how to handle all type of error you can
-read [Handle all errors](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react#handle-all-errors).
+💰 It is important to note that `react-error-boundary` do _not_ handle all type
+of errors. In our example it works nicely because as mentioned in extra credit 4
+that we are throwing error right in the function. It can also happen that some
+errors are not handled by `react-error-boundary`. To learn more about how to
+handle all type of error you can read
+[Handle all errors](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react#handle-all-errors).
 
 ### 7. 💯 reset the error boundary
 


### PR DESCRIPTION
The package-lock.json had the updated version for `@kentcdodds/react-workshop-app`, but the package.json didn't and there were some outdated links from react, as they are using react.dev now https://react.dev/blog/2023/03/16/introducing-react-dev

So this PR does:
- Update @kentcdodds/react-workshop-app to 6.0.2
- Update reactjs.org links to react.dev links
- Format the updated `.md` files with prettier